### PR TITLE
chore(renovate): enable forkProcessing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     "config:recommended"
   ],
+  forkProcessing: "enabled",
   configMigration: true,
   prHourlyLimit: 1,
   schedule: [ // utc timezone


### PR DESCRIPTION
By default, all forked repositories are skipped when in autodiscover mode by @renovatebot.

All @earthbuild repositories are forks.

We have two options:
- either detach our forks from @earthly or 
- enable forkProcessing by @renovatebot.

This enables fork processing by @renovatebot. The side effect is forks from our repositories are processed by @renovatebot if it is enabled for all repositories.