### PR TITLE
chore: lock docker to v25.0.2 for ubuntu 23.04

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -101,6 +101,15 @@
       ],
     },
     {
+      matchFileNames: [
+        'os/ubuntu-23.04/Earthfile',
+      ],
+      matchPackageNames: [
+        'docker/docker',
+      ],
+      allowedVersions: '25.0.2',
+    },
+    {
       automerge: true,
       matchPackageNames: [
         '*',

--- a/os/ubuntu-23.04/Earthfile
+++ b/os/ubuntu-23.04/Earthfile
@@ -9,6 +9,8 @@ IMPORT ../../common AS common
 ARG --global OS_IMAGE=ubuntu
 
 ARG --global OS_VERSION=23.04
+
+# Docker v25.0.2 is the last version supported by the Docker apt repo.
 # renovate: datasource=github-releases depName=docker/docker
 LET docker_package_version=25.0.2
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~lunar

--- a/os/ubuntu-23.04/Earthfile
+++ b/os/ubuntu-23.04/Earthfile
@@ -9,8 +9,6 @@ IMPORT ../../common AS common
 ARG --global OS_IMAGE=ubuntu
 
 ARG --global OS_VERSION=23.04
-
-# Docker v25.0.2 is the last version supported by the Docker apt repo.
 # renovate: datasource=github-releases depName=docker/docker
 LET docker_package_version=25.0.2
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~lunar


### PR DESCRIPTION
Lock Docker to v25.0.2 for Ubuntu 23.04 dind image.

The Docker apt repo supports the following versions

```console
root@buildkitsandbox:/# apt list -a docker-ce
Listing... Done
docker-ce/lunar 5:25.0.2-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:25.0.1-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:25.0.0-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.9-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.8-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.7-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.6-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.5-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.4-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.3-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.2-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.1-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:24.0.0-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:23.0.6-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:23.0.5-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:23.0.4-1~ubuntu.23.04~lunar arm64
docker-ce/lunar 5:23.0.3-1~ubuntu.23.04~lunar arm64
```