### PR TITLE
chore(renovate): lock docker to 28.1.1 for Ubuntu 20.04

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -101,6 +101,16 @@
       ],
     },
     {
+      // Lock docker to v28.1.1 for Ubuntu 20.04.
+      matchFileNames: [
+        'os/ubuntu-20.04/Earthfile',
+      ],
+      matchPackageNames: [
+        'docker/docker',
+      ],
+      allowedVersions: '28.1.1',
+    },
+    {
       // Lock docker to v25.0.2 for Ubuntu 23.04.
       matchFileNames: [
         'os/ubuntu-23.04/Earthfile',


### PR DESCRIPTION
The latest supported versions...

```console
root@buildkitsandbox:/# apt list -a docker-ce
Listing... Done
docker-ce/focal 5:28.1.1-1~ubuntu.20.04~focal amd64
docker-ce/focal 5:28.1.0-1~ubuntu.20.04~focal amd64
docker-ce/focal 5:28.0.4-1~ubuntu.20.04~focal amd64
...
```