### PR TITLE
ci: speed up test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   test:
     name: test
+    strategy:
+      matrix:
+        os: [alpine, ubuntu-20.04, ubuntu-23.04, ubuntu-24.04]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,7 +25,6 @@ jobs:
       FORCE_COLOR: 1
       EARTHLY_CONVERSION_PARALLELISM: "5"
       EARTHLY_INSTALL_ID: "earthbuild-dind-githubactions"
-      EARTHLY_REMOTE_CACHE: ghcr.io/earthbuild/ci-dind:cache
     steps:
       - uses: actions/checkout@v4
       # The dind (common+alpine-kind-test and common+ubuntu-kind-test) detects
@@ -48,4 +50,4 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
         if: github.event.pull_request.head.repo.full_name == github.repository
       - name: Run tests
-        run: earthly --ci -P --push +test
+        run: earthly --ci -P --push +test --OS=${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       FORCE_COLOR: 1
       EARTHLY_CONVERSION_PARALLELISM: "5"
       EARTHLY_INSTALL_ID: "earthbuild-dind-githubactions"
+      EARTHLY_REMOTE_CACHE: ghcr.io/earthbuild/ci-dind:cache
     steps:
       - uses: actions/checkout@v4
       # The dind (common+alpine-kind-test and common+ubuntu-kind-test) detects

--- a/Earthfile
+++ b/Earthfile
@@ -2,7 +2,7 @@ VERSION --wildcard-builds 0.8
 
 PROJECT earthly-technologies/core
 
-# test runs tests for all defined dind images in this repo
+# test runs tests for for the given OS image (os/*/Earthfile) in this repo
 test:
     ARG --required OS
     BUILD --pass-args ./os/$OS+test-build

--- a/Earthfile
+++ b/Earthfile
@@ -4,7 +4,8 @@ PROJECT earthly-technologies/core
 
 # test runs tests for all defined dind images in this repo
 test:
-    BUILD --pass-args ./os/*+test-build
+    ARG --required OS
+    BUILD --pass-args ./os/$OS+test-build
 
 # release expects to get a renovate branch in the form of renovate/<os>-dind-image, extracts the os and then kicks off its +release target
 # this is meant to be run by a github workflow


### PR DESCRIPTION
Speed up build (tests) by applying the GitHub matrix strategy.

The performance gain is ~16% (1 run).

Strangely, Ubuntu 24.04 takes 24 minutes to run tests.

<img width="641" height="452" alt="Screenshot 2025-07-15 at 00 10 11" src="https://github.com/user-attachments/assets/84586473-5688-4eea-8eb4-1efe09dbdc06" />
