### PR TITLE
chore: release ubuntu 23.04 dind

### DIFF
--- a/os/ubuntu-23.04/Earthfile
+++ b/os/ubuntu-23.04/Earthfile
@@ -10,7 +10,7 @@ ARG --global OS_IMAGE=ubuntu
 
 ARG --global OS_VERSION=23.04
 # renovate: datasource=github-releases depName=docker/docker
-LET docker_package_version=25.0.2
+LET docker_package_version=25.0.1
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~lunar
 
 # DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in


### PR DESCRIPTION
This forces @renovatebot to release the Ubuntu 23.04 dind by bumping Docker to 25.0.2.

Probably, first and final release of this dind in @EarthBuild.

PS. Currently, only @renovatebot can do releases of the dind images.