### PR TITLE
Potential fix for code scanning alert no. 3: Code injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           docker login ghcr.io --username ${{ github.actor }} --password "${{ secrets.GITHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
       - name: Build & Push image
+        env:
+          RENOVATE_BRANCH: ${{ github.head_ref }}
         run: |
-          earth --ci -P --push +release --RENOVATE_BRANCH=${{github.head_ref}} # default:ghcr.io
-          earth --ci -P --push +release --RENOVATE_BRANCH=${{github.head_ref}} --CR_HOST=docker.io
+          earth --ci -P --push +release --RENOVATE_BRANCH="$RENOVATE_BRANCH" # default:ghcr.io
+          earth --ci -P --push +release --RENOVATE_BRANCH="$RENOVATE_BRANCH" --CR_HOST=docker.io


### PR DESCRIPTION
Potential fix for [https://github.com/EarthBuild/dind/security/code-scanning/3](https://github.com/EarthBuild/dind/security/code-scanning/3)

To fix this safely without changing behavior, stop inlining `${{ github.head_ref }}` inside the shell command and instead pass it through a step `env` variable (or job-level env), then reference it as `"$RENOVATE_BRANCH"` in the shell. This follows GitHub’s recommended mitigation for expression-injection in `run:` blocks.

Best concrete fix in `.github/workflows/release.yml`:
- Edit the `Build & Push image` step.
- Add `env:` with `RENOVATE_BRANCH: ${{ github.head_ref }}`.
- Replace both command arguments `--RENOVATE_BRANCH=${{github.head_ref}}` with `--RENOVATE_BRANCH="$RENOVATE_BRANCH"`.

This preserves functionality while removing direct expression interpolation from shell script text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
