### PR TITLE
fx: for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
     paths: [ README.md ]
 
+permissions:
+  contents: read
+
 jobs:
   docker-hub-description:
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
Potential fix for [https://github.com/EarthBuild/dind/security/code-scanning/1](https://github.com/EarthBuild/dind/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.

Best fix here: define workflow-level permissions right after the trigger section (`on:`), before `jobs:`:

- `contents: read` is sufficient for checking out repository contents.
- No additional GitHub write scopes are needed for this workflow, since Docker Hub update uses `DOCKERHUB_TOKEN`, not GitHub write APIs.

File to change:
- `.github/workflows/dockerhub-description.yml`

Region to change:
- Insert `permissions:` block between the existing `on:` block and `jobs:` block.

No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
