### PR TITLE
feat: add alpine:3.24 dind

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,18 @@
         'README.md',
       ],
       matchStrings: [
+        '\\*\\s+\\`alpine-3\\.24-docker-(?<currentValue>.*?)\\`\\n',
+      ],
+      depNameTemplate: 'alpine_3_24/docker',
+      datasourceTemplate: 'repology',
+      versioningTemplate: 'loose',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        'README.md',
+      ],
+      matchStrings: [
         '\\*\\s+\\`ubuntu-(?<osVersion>\\d+\\.\\d+)-docker-(?<currentValue>.*?)-\\d+\\`\\n',
       ],
       depNameTemplate: 'moby/moby-{{{osVersion}}}',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         os:
           - alpine-3.22
           - alpine-3.23
+          - alpine-3.24
           - ubuntu-20.04
           - ubuntu-24.04
           - ubuntu-26.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ dependencies that will trigger new versions of the dind images such as the docke
     │   └── Earthfile
     ├── alpine-3.23
     │   └── Earthfile
+    ├── alpine-3.24
+    │   └── Earthfile
     ├── ubuntu-20.04
     │   └── Earthfile
     └── ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For information on how to use these images, please refer to [docker in EarthBuil
 This image supports the following Linux distributions:
 * alpine:3.22
 * alpine:3.23
+* alpine:3.24
 * ubuntu:20.04
 * ubuntu:24.04
 * ubuntu:26.04
@@ -18,6 +19,7 @@ This image supports the following Linux distributions:
 For which the current latest tags (respectively) are:
 * `alpine-3.22-docker-28.3.3-r2`
 * `alpine-3.23-docker-29.1.2-r1`
+* `alpine-3.24-docker-29.5.3-r0`
 * `ubuntu-20.04-docker-28.1.1-1`
 * `ubuntu-24.04-docker-28.5.1-1`
 * `ubuntu-26.04-docker-29.4.0-1`

--- a/os/alpine-3.22/Earthfile
+++ b/os/alpine-3.22/Earthfile
@@ -10,7 +10,7 @@ ARG --global OS_VERSION=3.22
 # renovate: datasource=repology depName=alpine_3_22/docker versioning=loose
 ARG --global DOCKER_VERSION=28.3.3-r5
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -33,7 +33,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+alpine-kind-test
     BUILD --pass-args common+alpine-docker-compose-test

--- a/os/alpine-3.23/Earthfile
+++ b/os/alpine-3.23/Earthfile
@@ -1,7 +1,5 @@
 VERSION --build-auto-skip 0.8
 
-PROJECT earthly-technologies/core
-
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 IMPORT ../../common AS common

--- a/os/alpine-3.23/Earthfile
+++ b/os/alpine-3.23/Earthfile
@@ -12,7 +12,7 @@ ARG --global OS_VERSION=3.23
 # renovate: datasource=repology depName=alpine_3_23/docker
 ARG --global DOCKER_VERSION=29.5.2-r0
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -35,7 +35,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+alpine-kind-test
     BUILD --pass-args common+alpine-docker-compose-test

--- a/os/alpine-3.24/Earthfile
+++ b/os/alpine-3.24/Earthfile
@@ -1,7 +1,5 @@
 VERSION --build-auto-skip 0.8
 
-PROJECT earthly-technologies/core
-
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 IMPORT ../../common AS common

--- a/os/alpine-3.24/Earthfile
+++ b/os/alpine-3.24/Earthfile
@@ -12,7 +12,7 @@ ARG --global OS_VERSION=3.24
 # renovate: datasource=repology depName=alpine_3_24/docker
 ARG --global DOCKER_VERSION=29.5.3-r0
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -35,7 +35,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+alpine-kind-test
     BUILD --pass-args common+alpine-docker-compose-test

--- a/os/alpine-3.24/Earthfile
+++ b/os/alpine-3.24/Earthfile
@@ -1,0 +1,42 @@
+VERSION --build-auto-skip 0.8
+
+PROJECT earthly-technologies/core
+
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+IMPORT ../../common AS common
+
+ARG --global OS_IMAGE=alpine
+
+ARG --global OS_VERSION=3.24
+# renovate: datasource=repology depName=alpine_3_24/docker
+ARG --global DOCKER_VERSION=29.5.3-r0
+
+# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
+
+# release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
+release:
+    RUN --no-cache date --utc +%Y%m%d%H%M%S > datetime
+    LET datetime="$(cat datetime)"
+    WAIT
+        BUILD --pass-args common+build-and-test --SUFFIX=$datetime
+    END
+    COPY --dir --pass-args common+get-image-info/image-info .
+    LET image_tag="$(cat image-info/tag)-$datetime"
+    BUILD --pass-args common+push-new-tag-multi-platform --TAG_WITH_DATE=$image_tag
+
+# test-build will build a test image that is pushed to a temporary registry and run tests against it
+test-build:
+    BUILD --pass-args common+build-and-test --IMAGE_NAME="dindtest"
+
+# build builds a dind image
+build:
+    BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
+
+# test runs test for a dind image
+# this is primarly used to run against a newly, temporariy image build by +test-build
+test:
+    BUILD --pass-args common+alpine-kind-test
+    BUILD --pass-args common+alpine-docker-compose-test
+    BUILD --pass-args common+test

--- a/os/ubuntu-20.04/Earthfile
+++ b/os/ubuntu-20.04/Earthfile
@@ -11,7 +11,7 @@ ARG --global OS_VERSION=20.04
 LET docker_package_version=28.1.1
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~focal
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -34,7 +34,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+ubuntu-kind-test
     BUILD --pass-args common+test

--- a/os/ubuntu-24.04/Earthfile
+++ b/os/ubuntu-24.04/Earthfile
@@ -11,7 +11,7 @@ ARG --global OS_VERSION=24.04
 LET docker_package_version=28.5.2
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~noble
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -34,7 +34,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+ubuntu-kind-test
     BUILD --pass-args common+test

--- a/os/ubuntu-26.04/Earthfile
+++ b/os/ubuntu-26.04/Earthfile
@@ -11,7 +11,7 @@ ARG --global OS_VERSION=26.04
 LET docker_package_version=29.4.0
 ARG --global DOCKER_VERSION=5:$docker_package_version-1~ubuntu.$OS_VERSION~resolute
 
-# DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
+# DIR_PATH must match the directory name of this Earthfile
 ARG --global DIR_PATH=$OS_IMAGE-$OS_VERSION
 
 # release builds the image using a new datetime as a suffix and run tests against the pushed image, then finally retag and push the image without the datetime suffix
@@ -34,7 +34,7 @@ build:
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64 common+build
 
 # test runs test for a dind image
-# this is primarly used to run against a newly, temporariy image build by +test-build
+# runs tests against the temporary image built by +test-build
 test:
     BUILD --pass-args common+ubuntu-kind-test
     BUILD --pass-args common+test


### PR DESCRIPTION
Adds support for a new Alpine-3.24 Docker-in-Docker (dind) image.
